### PR TITLE
Add instructions on how to use a particular version of the Checker Framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,33 @@ dependencies {
 }
 ```
 
+### Specifying a Checker Framework version
+
+To change the version of the Checker Framework used by the plugin, you can add
+`checkerFramework` entries to your `dependencies` block. For example, if you
+needed to use version 2.7.0 of the Checker Framework:
+
+```groovy
+dependencies {
+  checkerFramework 'org.checkerframework:checker-qual:2.7.0'
+  checkerFramework 'org.checkerframework:checker:2.7.0'
+  checkerFramework 'org.checkerframework:jdk8:2.7.0'
+}
+```
+
+You can also use a locally-built version of the Checker Framework via this
+mechanism:
+
+```groovy
+cfHome = String.valueOf(System.getenv("CHECKERFRAMEWORK"))
+
+dependencies {
+  checkerFramework files(cfHome + "/checker/dist/checker.jar")
+  checkerFramework files(cfHome + "/checker/dist/checker-qual.jar")
+  checkerFramework files(cfHome + "/checker/dist/jdk8.jar")
+}
+```
+
 ### Other options
 
 By default, the plugin applies the selected checkers to all `JavaCompile` targets.

--- a/README.md
+++ b/README.md
@@ -118,20 +118,22 @@ dependencies {
 
 ### Specifying a Checker Framework version
 
-To change the version of the Checker Framework used by the plugin, you can add
-`checkerFramework` entries to your `dependencies` block. For example, if you
-needed to use version 2.7.0 of the Checker Framework:
+To change the version of the Checker Framework used by the plugin (by default version 2.8.0),
+you should add `checkerFramework` entries to your `dependencies` block. 
+We recommend **explicitly** specifying the latest Checker Framework version, and updating
+often. You can find the latest version of the Checker Framework 
+[here](https://github.com/typetools/checker-framework/releases).
+For example, to use version 2.8.1 of the Checker Framework:
 
 ```groovy
 dependencies {
-  checkerFramework 'org.checkerframework:checker-qual:2.7.0'
-  checkerFramework 'org.checkerframework:checker:2.7.0'
-  checkerFramework 'org.checkerframework:jdk8:2.7.0'
+  checkerFramework 'org.checkerframework:checker-qual:2.8.1'
+  checkerFramework 'org.checkerframework:checker:2.8.1'
+  checkerFramework 'org.checkerframework:jdk8:2.8.1'
 }
 ```
 
-You can also use a locally-built version of the Checker Framework via this
-mechanism:
+You can also use a locally-built version of the Checker Framework:
 
 ```groovy
 cfHome = String.valueOf(System.getenv("CHECKERFRAMEWORK"))


### PR DESCRIPTION
#2 asks for a way to use a locally-built version of the Checker Framework. This ask is actually possible already, but is not well-documented. This PR adds documentation.

The old version of the CF's gradle support uses a special property (`-PcfLocal`) set on the command-line to switch to a hardcoded local CF location (`$CHECKERFRAMEWORK/`). I'm not a fan of this, because it hides some details that the user already has to worry about if they want to use this option (they would've needed to actually set `CHECKERFRAMEWORK` in their shell for this to work!), and we don't have clean installation scripts for the CF itself that guarantee this variable is set, so I'm against relying on it being present. That old script had a bunch of error-handling to deal with this problem.

The "gradle way" is to force the user to do the explicit configuration. This documentation change makes it clear how to do that - it shows how to use a locally-built CF version, or just any other CF version than the default. The expectation is that anyone using the plugin would explicitly set this.